### PR TITLE
added certificate path

### DIFF
--- a/providers/flagd/README.md
+++ b/providers/flagd/README.md
@@ -12,9 +12,9 @@ openfeature.SetProvider(flagd.NewProvider())
 ```  
 You may also provide additional options to configure the provider client
 ```
-flagd.WithService(HTTP | HTTPS | GRPC) // defaults to http, https is not currently implemented by flagd
-flagd.WithHost(string)              // defaults to localhost
-flagd.WithPort(uint16)               // defaults to 8080
+flagd.WithService(HTTP | HTTPS | GRPC)  // defaults to http 
+flagd.WithHost(string)                  // defaults to localhost
+flagd.WithPort(uint16)                  // defaults to 8080
 ```
 for example:
 ```

--- a/providers/flagd/pkg/provider.go
+++ b/providers/flagd/pkg/provider.go
@@ -13,9 +13,10 @@ type Provider struct {
 }
 
 type ProviderConfiguration struct {
-	Port        uint16
-	Host        string
-	ServiceName ServiceType
+	Port            uint16
+	Host            string
+	ServiceName     ServiceType
+	CertificatePath string
 }
 
 type ServiceType int
@@ -23,7 +24,7 @@ type ServiceType int
 const (
 	// HTTP argument for use in WithService, this is the default value
 	HTTP ServiceType = iota
-	// HTTPS argument for use in WithService, overrides the default value of http (NOT IMPLEMENTED BY FLAGD)
+	// HTTPS argument for use in WithService, overrides the default value of http
 	HTTPS
 	// GRPC argument for use in WithService, overrides the default value of http
 	GRPC
@@ -34,9 +35,10 @@ type ProviderOption func(*Provider)
 func NewProvider(opts ...ProviderOption) *Provider {
 	provider := &Provider{
 		providerConfiguration: &ProviderConfiguration{
-			ServiceName: HTTP,
-			Port:        8080,
-			Host:        "localhost",
+			ServiceName:     HTTP,
+			Port:            8080,
+			Host:            "localhost",
+			CertificatePath: "",
 		},
 	}
 	for _, opt := range opts {
@@ -46,6 +48,7 @@ func NewProvider(opts ...ProviderOption) *Provider {
 		provider.Service = GRPCService.NewGRPCService(
 			GRPCService.WithPort(provider.providerConfiguration.Port),
 			GRPCService.WithHost(provider.providerConfiguration.Host),
+			GRPCService.WithCertificatePath(provider.providerConfiguration.CertificatePath),
 		)
 	} else if provider.providerConfiguration.ServiceName == HTTPS {
 		provider.Service = HTTPService.NewHTTPService(
@@ -60,6 +63,13 @@ func NewProvider(opts ...ProviderOption) *Provider {
 		)
 	}
 	return provider
+}
+
+// WithCertificatePath specifies the location of the certificate to be used in the gRPC dial credentials. If certificate loading fails insecure credentials will be used instead
+func WithCertificatePath(path string) ProviderOption {
+	return func(p *Provider) {
+		p.providerConfiguration.CertificatePath = path
+	}
 }
 
 // WithPort specifies the port of the flagd server. Defaults to 8080

--- a/providers/flagd/pkg/service/grpc/client.go
+++ b/providers/flagd/pkg/service/grpc/client.go
@@ -1,11 +1,15 @@
 package grpc_service
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"io/ioutil"
 
 	log "github.com/sirupsen/logrus"
 	schemaV1 "go.buf.build/grpc/go/open-feature/flagd/schema/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
@@ -21,9 +25,20 @@ type gRPCClient struct {
 
 func (s *gRPCClient) connect() {
 	if s.conn == nil {
+		var credentials credentials.TransportCredentials
+		var err error
+		if s.GRPCServiceConfiguration.CertificatePath != "" {
+			credentials, err = loadTLSCredentials(s.GRPCServiceConfiguration.CertificatePath)
+			if err != nil {
+				log.Error(err)
+				credentials = insecure.NewCredentials()
+			}
+		} else {
+			credentials = insecure.NewCredentials()
+		}
 		conn, err := grpc.Dial(
 			fmt.Sprintf("%s:%d", s.GRPCServiceConfiguration.Host, s.GRPCServiceConfiguration.Port),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithTransportCredentials(credentials),
 			grpc.WithBlock(),
 		)
 		if err != nil {
@@ -46,4 +61,23 @@ func (s *gRPCClient) Instance() schemaV1.ServiceClient {
 // Configuration returns the current GRPCServiceConfiguration for the client
 func (s *gRPCClient) Configuration() *GRPCServiceConfiguration {
 	return s.GRPCServiceConfiguration
+}
+
+func loadTLSCredentials(serverCertPath string) (credentials.TransportCredentials, error) {
+	pemServerCA, err := ioutil.ReadFile(serverCertPath)
+	if err != nil {
+		return nil, err
+	}
+
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(pemServerCA) {
+		return nil, fmt.Errorf("failed to add server CA's certificate")
+	}
+
+	// Create the credentials and return it
+	config := &tls.Config{
+		RootCAs: certPool,
+	}
+
+	return credentials.NewTLS(config), nil
 }

--- a/providers/flagd/pkg/service/grpc/constructor.go
+++ b/providers/flagd/pkg/service/grpc/constructor.go
@@ -9,8 +9,9 @@ func NewGRPCService(opts ...GRPCServiceOption) *GRPCService {
 		host = "localhost"
 	)
 	serviceConfiguration := &GRPCServiceConfiguration{
-		Port: port,
-		Host: host,
+		Port:            port,
+		Host:            host,
+		CertificatePath: "",
 	}
 	svc := &GRPCService{
 		Client: &gRPCClient{
@@ -34,5 +35,12 @@ func WithPort(port uint16) GRPCServiceOption {
 func WithHost(host string) GRPCServiceOption {
 	return func(s *GRPCServiceConfiguration) {
 		s.Host = host
+	}
+}
+
+// WithCertificatePath specifies the fliepath of the certificate to be used in the gRPC dial credentials. If certificate loading fails or no path is provided insecure credentials will be used instead
+func WithCertificatePath(cPath string) GRPCServiceOption {
+	return func(s *GRPCServiceConfiguration) {
+		s.CertificatePath = cPath
 	}
 }

--- a/providers/flagd/pkg/service/grpc/service.go
+++ b/providers/flagd/pkg/service/grpc/service.go
@@ -14,8 +14,9 @@ import (
 )
 
 type GRPCServiceConfiguration struct {
-	Port uint16
-	Host string
+	Port            uint16
+	Host            string
+	CertificatePath string
 }
 
 // GRPCService handles the client side grpc interface for the flagd server


### PR DESCRIPTION
Added a CertificatePath option to the GRPCService, if there is an error while loading or none is provided then it defaults back to insecure.NewCredentials()
Updated HTTPS comments as it is now supported by flagd